### PR TITLE
CI: generate contributors.json and run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,37 +1,59 @@
 name: CI
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  pull_request: # run tests on every PR
 
 jobs:
-  test:
+  ci:
+    name: Lint & Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+
+    # ── Loop-prevention guard ──────────────────────────────────────────────
+    # Skip the entire job when the last push to the PR branch was made by
+    # github-actions[bot] (i.e. the commit-back step below), so we never
+    # re-trigger ourselves.
+    if: github.actor != 'github-actions[bot]'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+
     permissions:
-      contents: read
-    
+      contents: write  # needed to push contributors.json back to the PR branch
+
     steps:
-    - uses: actions/checkout@v3
-    
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.12'
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-    
-    - name: Validate data file exists
-      run: |
-        test -f src/data/automotive_data.csv
-    
-    - name: Check Python syntax
-      run: |
-        python -m py_compile src/app.py
-        python -m py_compile src/utils.py
-        python -m py_compile src/processing/transform.py
-        python -m py_compile src/plotting/charts.py
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Validate data file exists
+        run: test -f src/data/automotive_data.csv
+
+      - name: Run pytest
+        run: uv run pytest
+
+      - name: Generate contributor data
+        run: uv run python scripts/contribution/authors.py
+
+      # ── Commit & push generated file back to the PR branch ────────────────
+      # Uses the built-in GITHUB_TOKEN, so the push is attributed to
+      # `github-actions[bot]` – the actor filtered out by the `if` guard above.
+      - name: Commit and push contributors.json
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/cleaned/contributors.json
+          # Only commit when there is actually a change; exit 0 otherwise.
+          git diff --cached --quiet || git commit -m "chore: update contributors.json"
+          git push origin HEAD:${{ github.head_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}  # check out the branch, not a detached HEAD
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -56,4 +58,5 @@ jobs:
           git add data/cleaned/contributors.json
           # Only commit when there is actually a change; exit 0 otherwise.
           git diff --cached --quiet || git commit -m "chore: update contributors.json"
-          git push origin HEAD:${{ github.head_ref }}
+          git pull --rebase origin ${{ github.head_ref }}
+          git push --force-with-lease origin HEAD:${{ github.head_ref }}

--- a/data/cleaned/contributors.json
+++ b/data/cleaned/contributors.json
@@ -1,0 +1,5 @@
+{
+  "transform": [
+    "Johannes Johansson"
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
   "streamlit>=1.28.0",
-  "pandas>=2.0.0",
+  "pandas>=2.2.0",
   "plotly>=5.17.0",
 ]
 

--- a/scripts/contribution/authors.py
+++ b/scripts/contribution/authors.py
@@ -1,0 +1,62 @@
+"""Script for rendering contribution pages."""
+
+from collections import Counter, defaultdict
+import json
+from pathlib import Path
+import subprocess
+
+ROOT = Path(__file__).parents[2]
+
+
+def get_raw_contributors(pages_dir: Path) -> dict[str, Counter]:
+    """Run git blame on each page file and count lines per author."""
+    raw_contributors: dict[str, Counter] = defaultdict(Counter)
+    for page_file in sorted(pages_dir.glob("*.py")):
+        if page_file.name.startswith("_"):
+            continue  # skip __init__.py or similar
+
+        result = subprocess.run(
+            [  # noqa: S603 S607
+                "git",
+                "blame",
+                "--line-porcelain",  # one author header per line
+                "--",
+                str(page_file),
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=ROOT,
+            check=False,
+        )
+        for line in result.stdout.splitlines():
+            if line.startswith("author "):
+                author = line[len("author ") :].strip()
+                raw_contributors[page_file.name][author] += 1
+
+    return raw_contributors
+
+
+def build_contributors(raw_contributors: dict[str, Counter]) -> dict[str, list]:
+    """Build and print the contributors dict sorted by line count."""
+    contributors: dict[str, list] = {}
+    for page, line_counts in sorted(raw_contributors.items()):
+        sorted_authors = sorted(line_counts.items(), key=lambda x: x[1], reverse=True)
+        authors_str = ", ".join(f"{author} ({count})" for author, count in sorted_authors)
+        print(f"{page}: {authors_str}")  # noqa: T201
+        contributors[page.removesuffix(".py")] = [x[0] for x in sorted_authors]
+    return contributors
+
+
+def save_contributors(contributors: dict[str, list], output_path: Path) -> None:
+    """Save contributors dict to a JSON file."""
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(contributors, f, indent=2, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    pages_dir = ROOT / "src/processing"
+    raw_contributors = get_raw_contributors(pages_dir)
+    contributors = build_contributors(raw_contributors)
+    output_path = ROOT / "data/cleaned/contributors.json"
+    save_contributors(contributors, output_path)

--- a/src/processing/__init__.py
+++ b/src/processing/__init__.py
@@ -1,1 +1,2 @@
 """Processing module for automotive data transformations."""
+# hej

--- a/tests/unit/processing/test_transform.py
+++ b/tests/unit/processing/test_transform.py
@@ -115,7 +115,7 @@ class TestAggregateByTime:
     """Test suite for aggregate_by_time function."""
 
     @pytest.mark.parametrize(("freq", "expected_freq"), [
-        ("H", "H"),
+        ("h", "h"),
         ("D", "D"),
     ])
     def test_aggregate_by_time_frequencies(self, freq: str, expected_freq: str) -> None:
@@ -163,7 +163,7 @@ class TestAggregateByTime:
         })
 
         # Act
-        result_df = aggregate_by_time(input_df, freq='H')
+        result_df = aggregate_by_time(input_df, freq='h')
 
         # Assert
         assert len(result_df) == 2  # Two hourly buckets
@@ -190,7 +190,7 @@ class TestAggregateByTime:
         })
 
         # Act
-        result_df = aggregate_by_time(input_df, freq='H')
+        result_df = aggregate_by_time(input_df, freq='h')
 
         # Assert
         assert len(result_df) == 4  # 2 vehicles * 2 hours
@@ -211,7 +211,7 @@ class TestAggregateByTime:
         original_index = input_df.index.to_numpy()
 
         # Act
-        aggregate_by_time(input_df, freq='H')
+        aggregate_by_time(input_df, freq='h')
 
         # Assert
         assert (input_df.index.to_numpy() == original_index).all()


### PR DESCRIPTION
Update CI to run lint/tests with uv and Python 3.12, generate a contributors.json, and push it back to the PR branch. Add a loop-prevention guard so commits made by github-actions[bot] won't re-trigger the job. Switch to actions/checkout@v4 and setup-python@v5, install dev deps via uv, run pytest, then run a new script to build contributor data and commit only when changed. Add scripts/contribution/authors.py (uses git blame to aggregate authors per src/processing/*.py and write data/cleaned/contributors.json) and a placeholder data/cleaned/.gitkeep. Permissions updated to allow writing contents for the automated push.